### PR TITLE
Fix for #54, crash when starting with autostart disabled.

### DIFF
--- a/discover_overlay/autostart.py
+++ b/discover_overlay/autostart.py
@@ -50,4 +50,4 @@ class Autostart:
             pass
 
     def is_auto(self):
-        return True if self.auto else None
+        return True if self.auto else False


### PR DESCRIPTION
Changed autostart.py to return False rather than None if autostart is disabled. `autostart_opt.set_active(self.a.is_auto())` seems to crash when getting a None type from `self.a.is_auto()`.