### PR TITLE
Added option to only display users that are speaking

### DIFF
--- a/discover_overlay/voice_overlay.py
+++ b/discover_overlay/voice_overlay.py
@@ -12,6 +12,8 @@ import logging
 
 
 class VoiceOverlayWindow(OverlayWindow):
+
+
     def __init__(self):
         OverlayWindow.__init__(self)
 
@@ -32,6 +34,7 @@ class VoiceOverlayWindow(OverlayWindow):
         self.wind_col = [0.0, 0.0, 0.0, 0.0]
         self.mute_col = [0.7, 0.0, 0.0, 1.0]
         self.userlist = []
+        self.users_to_draw = []
         self.connected = False
         self.force_location()
         self.def_avatar = get_image(self.recv_avatar,
@@ -80,6 +83,9 @@ class VoiceOverlayWindow(OverlayWindow):
     def set_square_avatar(self, i):
         self.round_avatar = not i
         self.redraw()
+
+    def set_only_speaking(self, only_speaking):
+        self.only_speaking = only_speaking
 
     def set_wind_col(self):
         self.col(self.wind_col)
@@ -136,11 +142,22 @@ class VoiceOverlayWindow(OverlayWindow):
         if not self.connected:
             return
 
+        # Gather which users to draw
+        if self.only_speaking:
+            self.users_to_draw = self.userlist[:]
+            # Remove users that arent speaking
+            for user in self.userlist:
+                speaking = "speaking" in user and user["speaking"]
+                if not speaking:
+                    self.users_to_draw.remove(user)
+        else:
+            self.users_to_draw = self.userlist
+
         # Get size of window
         (w, h) = self.get_size()
         # Calculate height needed to show overlay
-        height = (len(self.userlist) * self.avatar_size) + \
-            (len(self.userlist) + 1) * self.icon_spacing
+        height = (len(self.users_to_draw) * self.avatar_size) + \
+            (len(self.users_to_draw) + 1) * self.icon_spacing
 
         # Choose where to start drawing
         rh = 0 + self.vert_edge_padding
@@ -149,8 +166,8 @@ class VoiceOverlayWindow(OverlayWindow):
             rh = (h / 2) - (height / 2)
         elif self.align_vert == 2:
             rh = h - height - self.vert_edge_padding
-        # Iterate users in room.
-        for user in self.userlist:
+
+        for user in self.users_to_draw:
             self.draw_avatar(context, user, rh)
             # Shift the relative position down to next location
             rh += self.avatar_size + self.icon_spacing

--- a/discover_overlay/voice_settings.py
+++ b/discover_overlay/voice_settings.py
@@ -55,6 +55,7 @@ class VoiceSettingsWindow(SettingsWindow):
         self.font = config.get("main", "font", fallback=None)
         self.square_avatar = config.getboolean(
             "main", "square_avatar", fallback=False)
+        self.only_speaking = config.getboolean("main", "only_speaking", fallback=True)
         self.monitor = config.get("main", "monitor", fallback="None")
         self.vert_edge_padding = config.getint(
             "main", "vert_edge_padding", fallback=0)
@@ -77,6 +78,7 @@ class VoiceSettingsWindow(SettingsWindow):
         self.overlay.set_icon_spacing(self.icon_spacing)
         self.overlay.set_text_padding(self.text_padding)
         self.overlay.set_square_avatar(self.square_avatar)
+        self.overlay.set_only_speaking(self.only_speaking)
         self.overlay.set_monitor(self.get_monitor_index(self.monitor))
         self.overlay.set_vert_edge_padding(self.vert_edge_padding)
         self.overlay.set_horz_edge_padding(self.horz_edge_padding)
@@ -109,6 +111,7 @@ class VoiceSettingsWindow(SettingsWindow):
         if self.font:
             config.set("main", "font", self.font)
         config.set("main", "square_avatar", "%d" % (int(self.square_avatar)))
+        config.set("main", "only_speaking", "%d" % (int(self.only_speaking)))
         config.set("main", "monitor", self.monitor)
         config.set("main", "vert_edge_padding", "%d" %
                    (self.vert_edge_padding))
@@ -256,6 +259,11 @@ class VoiceSettingsWindow(SettingsWindow):
         square_avatar.set_active(self.square_avatar)
         square_avatar.connect("toggled", self.change_square_avatar)
 
+        only_speaking_label = Gtk.Label.new("Only Speaking")
+        only_speaking = Gtk.CheckButton.new()
+        only_speaking.set_active(self.only_speaking)
+        only_speaking.connect("toggled", self.change_only_speaking)
+
         box.attach(font_label, 0, 0, 1, 1)
         box.attach(font, 1, 0, 1, 1)
         box.attach(bg_col_label, 0, 1, 1, 1)
@@ -284,6 +292,8 @@ class VoiceSettingsWindow(SettingsWindow):
         box.attach(horz_edge_padding, 1, 14, 1, 1)
         box.attach(square_avatar_label, 0, 15, 1, 1)
         box.attach(square_avatar, 1, 15, 1, 1)
+        box.attach(only_speaking_label, 0, 16, 1, 1)
+        box.attach(only_speaking, 1, 16, 1, 1)
 
         self.add(box)
 
@@ -435,4 +445,10 @@ class VoiceSettingsWindow(SettingsWindow):
         self.overlay.set_square_avatar(button.get_active())
 
         self.square_avatar = button.get_active()
+        self.save_config()
+
+    def change_only_speaking(self, button):
+        self.overlay.set_only_speaking(button.get_active())
+
+        self.only_speaking = button.get_active()
         self.save_config()


### PR DESCRIPTION
Works like the actual discord overlay. Only difference is that it doesn't sort by the length of time a person has been speaking for, which is perhaps a todo another time.