### PR TITLE
Add "Higlight Self" option

### DIFF
--- a/discover_overlay/discover_overlay.py
+++ b/discover_overlay/discover_overlay.py
@@ -38,11 +38,23 @@ import logging
 
 class Discover:
     def __init__(self):
-        pass
+        self.a = Autostart("discover_overlay")
+        # a.set_autostart(True)
+        self.create_gui()
+        self.connection = DiscordConnector(
+            self.text_settings, self.voice_settings,
+            self.text_overlay, self.voice_overlay)
+        self.connection.connect()
+        GLib.timeout_add((1000 / 60), self.connection.do_read)
+
+        try:
+            Gtk.main()
+        except:
+            pass
 
     def create_gui(self):
-        self.voice_overlay = VoiceOverlayWindow()
-        self.text_overlay = TextOverlayWindow()
+        self.voice_overlay = VoiceOverlayWindow(self)
+        self.text_overlay = TextOverlayWindow(self)
         self.menu = self.make_menu()
         self.make_sys_tray_icon(self.menu)
         self.voice_settings = VoiceSettingsWindow(self.voice_overlay)
@@ -103,23 +115,7 @@ class Discover:
     def close(self, a=None, b=None, c=None):
         Gtk.main_quit()
 
-    def main(self):
-        self.a = Autostart("discover_overlay")
-        # a.set_autostart(True)
-        self.create_gui()
-        self.connection = DiscordConnector(
-            self.text_settings, self.voice_settings,
-            self.text_overlay, self.voice_overlay)
-        self.connection.connect()
-        GLib.timeout_add((1000 / 60), self.connection.do_read)
-
-        try:
-            Gtk.main()
-        except:
-            pass
-
 
 def entrypoint():
     logging.getLogger().setLevel(logging.INFO)
     discover = Discover()
-    discover.main()

--- a/discover_overlay/text_overlay.py
+++ b/discover_overlay/text_overlay.py
@@ -15,8 +15,9 @@ from .image_getter import get_surface
 
 
 class TextOverlayWindow(OverlayWindow):
-    def __init__(self):
+    def __init__(self, discover):
         OverlayWindow.__init__(self)
+        self.discover = discover
         self.text_spacing = 4
         self.content = []
         self.text_font = None

--- a/discover_overlay/voice_settings.py
+++ b/discover_overlay/voice_settings.py
@@ -57,6 +57,8 @@ class VoiceSettingsWindow(SettingsWindow):
             "main", "square_avatar", fallback=False)
         self.only_speaking = config.getboolean(
             "main", "only_speaking", fallback=False)
+        self.highlight_self = config.getboolean(
+            "main", "highlight_self", fallback=False)
         self.monitor = config.get("main", "monitor", fallback="None")
         self.vert_edge_padding = config.getint(
             "main", "vert_edge_padding", fallback=0)
@@ -80,6 +82,7 @@ class VoiceSettingsWindow(SettingsWindow):
         self.overlay.set_text_padding(self.text_padding)
         self.overlay.set_square_avatar(self.square_avatar)
         self.overlay.set_only_speaking(self.only_speaking)
+        self.overlay.set_highlight_self(self.highlight_self)
         self.overlay.set_monitor(self.get_monitor_index(self.monitor))
         self.overlay.set_vert_edge_padding(self.vert_edge_padding)
         self.overlay.set_horz_edge_padding(self.horz_edge_padding)
@@ -113,6 +116,7 @@ class VoiceSettingsWindow(SettingsWindow):
             config.set("main", "font", self.font)
         config.set("main", "square_avatar", "%d" % (int(self.square_avatar)))
         config.set("main", "only_speaking", "%d" % (int(self.only_speaking)))
+        config.set("main", "highlight_self", "%d" % (int(self.highlight_self)))
         config.set("main", "monitor", self.monitor)
         config.set("main", "vert_edge_padding", "%d" %
                    (self.vert_edge_padding))
@@ -265,6 +269,11 @@ class VoiceSettingsWindow(SettingsWindow):
         only_speaking.set_active(self.only_speaking)
         only_speaking.connect("toggled", self.change_only_speaking)
 
+        highlight_self_label = Gtk.Label.new("Highlight Self")
+        highlight_self = Gtk.CheckButton.new()
+        highlight_self.set_active(self.highlight_self)
+        highlight_self.connect("toggled", self.change_highlight_self)
+
         box.attach(font_label, 0, 0, 1, 1)
         box.attach(font, 1, 0, 1, 1)
         box.attach(bg_col_label, 0, 1, 1, 1)
@@ -295,6 +304,8 @@ class VoiceSettingsWindow(SettingsWindow):
         box.attach(square_avatar, 1, 15, 1, 1)
         box.attach(only_speaking_label, 0, 16, 1, 1)
         box.attach(only_speaking, 1, 16, 1, 1)
+        box.attach(highlight_self_label, 0, 17, 1, 1)
+        box.attach(highlight_self, 1, 17, 1, 1)
 
         self.add(box)
 
@@ -452,4 +463,10 @@ class VoiceSettingsWindow(SettingsWindow):
         self.overlay.set_only_speaking(button.get_active())
 
         self.only_speaking = button.get_active()
+        self.save_config()
+
+    def change_highlight_self(self, button):
+        self.overlay.set_highlight_self(button.get_active())
+
+        self.highlight_self = button.get_active()
         self.save_config()


### PR DESCRIPTION
This option places yourself at the top of the list.
If you have only speaking on, this will bypass that as well.

This is useful to see whether you are muted / your voice is being picked up / you are deafened etc.

I also rearranged some code in `discover_overlay.py` for better ide code detection (fields not being declared in `__init__` confuses it)