### PR TITLE
Fix icon not displaying when falling back to systray

### DIFF
--- a/discover_overlay/discover_overlay.py
+++ b/discover_overlay/discover_overlay.py
@@ -87,7 +87,7 @@ class Discover:
         except Exception as e:
             # Create System Tray
             logging.info("Falling back to Systray : %s" % (e))
-            self.tray = Gtk.StatusIcon.new_from_icon_name("discover_overlay")
+            self.tray = Gtk.StatusIcon.new_from_icon_name("discover-overlay")
             self.tray.connect('popup-menu', self.show_menu)
 
     def make_menu(self):

--- a/discover_overlay/settings_window.py
+++ b/discover_overlay/settings_window.py
@@ -20,7 +20,9 @@ class MainSettingsWindow(Gtk.Window):
         self.text_overlay = text_overlay
         self.voice_overlay = voice_overlay
         self.set_title("Discover Overlay Configuration")
-        
+        self.set_icon_from_file("discover-overlay.png")
+        self.set_default_size(280, 180)
+
         # Create
         nb = Gtk.Notebook()
         #nb.set_tab_pos(Gtk.POS_TOP)


### PR DESCRIPTION
I noticed in #56 that there were some comments about the icon not working when it falls back to systray with the message:
`INFO:root:Falling back to Systray : Namespace AppIndicator3 not available`

I also noticed this behavior on my system:

![Screenshot_20201018_194856](https://user-images.githubusercontent.com/17362949/96397230-ebd32680-117d-11eb-8708-384ec3cfaeb0.png)

I was able to find and solve the issue with systray not finding the icon and also happened to discover that the reason my system was falling back to systray in the first place was because I needed to run `sudo apt install gir1.2-appindicator3-0.1` as that fixed the error (`ImportError: cannot import name AppIndicator3, introspection typelib not found`) that was triggering the try/catch and falling back to the Systray icon.


This PR also sets up the icon in task manager so that when the settings page is open users see the discover-overlay icon rather than the default X icon
![Screenshot_20201018_205518](https://user-images.githubusercontent.com/17362949/96399855-3c4d8280-1184-11eb-939c-ba330aa20a69.png)
