### PR TITLE
Vertically center voice overlay usernames

### DIFF
--- a/discover_overlay/voice_overlay.py
+++ b/discover_overlay/voice_overlay.py
@@ -372,8 +372,12 @@ class VoiceOverlayWindow(OverlayWindow):
             context.set_font_face(cairo.ToyFontFace(
                 self.text_font, cairo.FontSlant.NORMAL, cairo.FontWeight.NORMAL))
         context.set_font_size(self.text_size)
+
+        # Get text size details
+        f_ascent, f_descent, f_height, f_max_dx, f_max_dy = context.font_extents()
         _xb, _yb, width, height, _dx, _dy = context.text_extents(string)
-        height_offset = (self.avatar_size / 2) - (height / 2)
+
+        height_offset = (self.avatar_size / 2) - (f_height / 2)
         if self.align_right:
             context.move_to(0, 0)
             self.set_norm_col()
@@ -381,14 +385,14 @@ class VoiceOverlayWindow(OverlayWindow):
                 pos_x - width - (self.text_pad * 2),
                 pos_y + height_offset - self.text_pad,
                 width + (self.text_pad * 4),
-                height + (self.text_pad * 2)
+                f_height + (self.text_pad * 2)
             )
             context.fill()
 
             self.set_text_col()
             context.move_to(
                 pos_x - width - self.text_pad,
-                pos_y + height_offset + height
+                pos_y + height_offset + f_height - f_descent
             )
             context.show_text(string)
         else:
@@ -398,13 +402,15 @@ class VoiceOverlayWindow(OverlayWindow):
                 pos_x - (self.text_pad * 2),
                 pos_y + height_offset - self.text_pad,
                 width + (self.text_pad * 4),
-                height + (self.text_pad * 2)
+                f_height + (self.text_pad * 2)
             )
             context.fill()
 
             self.set_text_col()
-            context.move_to(pos_x + self.text_pad,
-                            pos_y + height_offset + height)
+            context.move_to(
+                pos_x + self.text_pad,
+                pos_y + height_offset + f_height - f_descent
+            )
             context.show_text(string)
 
     def draw_avatar_pix(self, context, pixbuf, pos_x, pos_y, border_colour):

--- a/discover_overlay/voice_overlay.py
+++ b/discover_overlay/voice_overlay.py
@@ -30,6 +30,7 @@ class VoiceOverlayWindow(OverlayWindow):
         self.text_pad = 6
         self.text_font = None
         self.text_size = 13
+        self.text_baseline_adj = 0
         self.icon_spacing = 8
         self.vert_edge_padding = 0
         self.horz_edge_padding = 0
@@ -101,6 +102,13 @@ class VoiceOverlayWindow(OverlayWindow):
         Set padding between text and border
         """
         self.text_pad = i
+        self.redraw()
+
+    def set_text_baseline_adj(self, i):
+        """
+        Set padding between text and border
+        """
+        self.text_baseline_adj = i
         self.redraw()
 
     def set_vert_edge_padding(self, i):
@@ -378,6 +386,8 @@ class VoiceOverlayWindow(OverlayWindow):
         _xb, _yb, width, height, _dx, _dy = context.text_extents(string)
 
         height_offset = (self.avatar_size / 2) - (f_height / 2)
+        text_y_offset = height_offset + f_height - f_descent + self.text_baseline_adj
+
         if self.align_right:
             context.move_to(0, 0)
             self.set_norm_col()
@@ -392,7 +402,7 @@ class VoiceOverlayWindow(OverlayWindow):
             self.set_text_col()
             context.move_to(
                 pos_x - width - self.text_pad,
-                pos_y + height_offset + f_height - f_descent
+                pos_y + text_y_offset
             )
             context.show_text(string)
         else:
@@ -409,7 +419,7 @@ class VoiceOverlayWindow(OverlayWindow):
             self.set_text_col()
             context.move_to(
                 pos_x + self.text_pad,
-                pos_y + height_offset + f_height - f_descent
+                pos_y + text_y_offset 
             )
             context.show_text(string)
 

--- a/discover_overlay/voice_settings.py
+++ b/discover_overlay/voice_settings.py
@@ -39,6 +39,7 @@ class VoiceSettingsWindow(SettingsWindow):
         self.avatar_size = None
         self.icon_spacing = None
         self.text_padding = None
+        self.text_baseline_adj = None
         self.font = None
         self.square_avatar = None
         self.only_speaking = None
@@ -88,6 +89,7 @@ class VoiceSettingsWindow(SettingsWindow):
         self.avatar_size = config.getint("main", "avatar_size", fallback=48)
         self.icon_spacing = config.getint("main", "icon_spacing", fallback=8)
         self.text_padding = config.getint("main", "text_padding", fallback=6)
+        self.text_baseline_adj = config.getint("main", "text_baseline_adj", fallback=0)
         self.font = config.get("main", "font", fallback=None)
         self.square_avatar = config.getboolean(
             "main", "square_avatar", fallback=False)
@@ -119,6 +121,7 @@ class VoiceSettingsWindow(SettingsWindow):
         self.overlay.set_avatar_size(self.avatar_size)
         self.overlay.set_icon_spacing(self.icon_spacing)
         self.overlay.set_text_padding(self.text_padding)
+        self.overlay.set_text_baseline_adj(self.text_baseline_adj)
         self.overlay.set_square_avatar(self.square_avatar)
         self.overlay.set_only_speaking(self.only_speaking)
         self.overlay.set_highlight_self(self.highlight_self)
@@ -157,6 +160,7 @@ class VoiceSettingsWindow(SettingsWindow):
         config.set("main", "avatar_size", "%d" % (self.avatar_size))
         config.set("main", "icon_spacing", "%d" % (self.icon_spacing))
         config.set("main", "text_padding", "%d" % (self.text_padding))
+        config.set("main", "text_baseline_adj", "%d" % (self.text_baseline_adj))
         if self.font:
             config.set("main", "font", self.font)
         config.set("main", "square_avatar", "%d" % (int(self.square_avatar)))
@@ -291,6 +295,13 @@ class VoiceSettingsWindow(SettingsWindow):
         text_padding = Gtk.SpinButton.new(text_padding_adjustment, 0, 0)
         text_padding.connect("value-changed", self.change_text_padding)
 
+        # Text Baseline Adjustment
+        text_baseline_label = Gtk.Label.new("Text Vertical Offset")
+        text_baseline_adjustment = Gtk.Adjustment.new(
+            self.text_baseline_adj, -32, 32, 1, 1, 0)
+        text_baseline = Gtk.SpinButton.new(text_baseline_adjustment, 0, 0)
+        text_baseline.connect("value-changed", self.change_text_baseline)
+
         # Edge padding
         vert_edge_padding_label = Gtk.Label.new("Vertical Edge Padding")
         vert_edge_padding_adjustment = Gtk.Adjustment.new(
@@ -365,20 +376,22 @@ class VoiceSettingsWindow(SettingsWindow):
         box.attach(icon_spacing, 1, 11, 1, 1)
         box.attach(text_padding_label, 0, 12, 1, 1)
         box.attach(text_padding, 1, 12, 1, 1)
-        box.attach(vert_edge_padding_label, 0, 13, 1, 1)
-        box.attach(vert_edge_padding, 1, 13, 1, 1)
-        box.attach(horz_edge_padding_label, 0, 14, 1, 1)
-        box.attach(horz_edge_padding, 1, 14, 1, 1)
-        box.attach(square_avatar_label, 0, 15, 1, 1)
-        box.attach(square_avatar, 1, 15, 1, 1)
-        box.attach(only_speaking_label, 0, 16, 1, 1)
-        box.attach(only_speaking, 1, 16, 1, 1)
-        box.attach(highlight_self_label, 0, 17, 1, 1)
-        box.attach(highlight_self, 1, 17, 1, 1)
-        box.attach(icon_only_label, 0, 18, 1, 1)
-        box.attach(icon_only, 1, 18, 1, 1)
-        box.attach(order_label, 0, 19, 1, 1)
-        box.attach(order, 1, 19, 1, 1)
+        box.attach(text_baseline_label, 0, 13, 1, 1)
+        box.attach(text_baseline, 1, 13, 1, 1)
+        box.attach(vert_edge_padding_label, 0, 14, 1, 1)
+        box.attach(vert_edge_padding, 1, 14, 1, 1)
+        box.attach(horz_edge_padding_label, 0, 15, 1, 1)
+        box.attach(horz_edge_padding, 1, 15, 1, 1)
+        box.attach(square_avatar_label, 0, 16, 1, 1)
+        box.attach(square_avatar, 1, 16, 1, 1)
+        box.attach(only_speaking_label, 0, 17, 1, 1)
+        box.attach(only_speaking, 1, 17, 1, 1)
+        box.attach(highlight_self_label, 0, 18, 1, 1)
+        box.attach(highlight_self, 1, 18, 1, 1)
+        box.attach(icon_only_label, 0, 19, 1, 1)
+        box.attach(icon_only, 1, 19, 1, 1)
+        box.attach(order_label, 0, 20, 1, 1)
+        box.attach(order, 1, 20, 1, 1)
 
         self.add(box)
 
@@ -465,6 +478,15 @@ class VoiceSettingsWindow(SettingsWindow):
         self.overlay.set_text_padding(button.get_value())
 
         self.text_padding = button.get_value()
+        self.save_config()
+
+    def change_text_baseline(self, button):
+        """
+        Text baseline changed
+        """
+        self.overlay.set_text_baseline_adj(button.get_value())
+
+        self.text_baseline_adj = button.get_value()
         self.save_config()
 
     def change_vert_edge_padding(self, button):


### PR DESCRIPTION
Fixes #114 

The basic idea, is instead of deriving the position of the text off of the instance of rendered text, which differs in height depending on whether things like diacritics, capitals, and other special characters exist in the text, we look at the font properties itself for the height and baseline.

This is the recommended way of computing the y value for text for alignment, as per the cairo graphics project's vertical centering example: https://www.cairographics.org/tutorial/#L2textalign

Additionally, I've added an extra properties menu field for a baseline adjustment, which will allow the user to manually adjust the text up and down, because some fonts do not visually center properly regardless.