### PR TITLE
Merge .desktop files into a single menu entry

### DIFF
--- a/discover_overlay.desktop
+++ b/discover_overlay.desktop
@@ -5,4 +5,14 @@ Exec=discover-overlay
 Icon=discover-overlay
 Terminal=false
 Type=Application
-Categories=Network;
+Actions=close;configure
+Categories=Utility;TelephonyTools
+Keywords=Discord
+
+[Desktop Action close]
+Name=Close
+Exec=discover-overlay --close
+
+[Desktop Action configure]
+Name=Settings
+Exec=discover-overlay --configure

--- a/discover_overlay_close.desktop
+++ b/discover_overlay_close.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Name=Discover Overlay - Close
-Comment=Close Discover Overlay
-Exec=discover-overlay --close
-Icon=discover-overlay
-Terminal=false
-Type=Application
-Categories=Network;

--- a/discover_overlay_conf.desktop
+++ b/discover_overlay_conf.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Name=Discover Overlay - Config
-Comment=Open configuration for Discover Overlay
-Exec=discover-overlay --configure
-Icon=discover-overlay
-Terminal=false
-Type=Application
-Categories=Network;


### PR DESCRIPTION
This causes a single item to appear in the Gnome application menu.  Close and Settings can be accessed by right-clicking on the icon.

Fixes #138.