### PR TITLE
fix KeyError: 'embeds'

### DIFF
--- a/discover_overlay/discord_connector.py
+++ b/discover_overlay/discord_connector.py
@@ -215,12 +215,12 @@ class DiscordConnector:
             return message["content_parsed"]
         elif "content" in message and len(message["content"]) > 0:
             return message["content"]
-        elif len(message["embeds"]) == 1:
+        elif "embeds" in message and len(message["embeds"]) == 1:
             if "rawDescription" in message["embeds"][0]:
                 return message["embeds"][0]["rawDescription"]
             if "author" in message["embeds"][0]:
                 return message["embeds"][0]["author"]["name"]
-        elif 'attachments' in message and len(message["attachments"]) == 1:
+        elif "attachments" in message and len(message["attachments"]) == 1:
             return ""
         return ""
 
@@ -229,7 +229,7 @@ class DiscordConnector:
         Messages with attachments come in different forms, decide what is and is
         not an attachment
         """
-        if len(message["attachments"]) == 1:
+        if "attachments" in message and len(message["attachments"]) == 1:
             return message["attachments"]
         return None
 


### PR DESCRIPTION
Got the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/discover_overlay/discord_connector.py", line 638, in do_read
    self.on_message(msg)
  File "/usr/lib/python3.9/site-packages/discover_overlay/discord_connector.py", line 324, in on_message
    self.update_text(j["data"]["message"])
  File "/usr/lib/python3.9/site-packages/discover_overlay/discord_connector.py", line 188, in update_text
    'content': self.get_message_from_message(message_in),
  File "/usr/lib/python3.9/site-packages/discover_overlay/discord_connector.py", line 217, in get_message_from_message
    elif len(message["embeds"]) == 1:
KeyError: 'embeds'
```