### PR TITLE
Fix missing language fallback causing the program to crash

### DIFF
--- a/discover_overlay/about_settings.py
+++ b/discover_overlay/about_settings.py
@@ -22,7 +22,7 @@ from .settings import SettingsWindow
 
 log = logging.getLogger(__name__)
 t = gettext.translation('default', pkg_resources.resource_filename(
-    'discover_overlay', 'locales'))
+    'discover_overlay', 'locales'), fallback=True)
 _ = t.gettext
 
 gi.require_version("Gtk", "3.0")

--- a/discover_overlay/discover_overlay.py
+++ b/discover_overlay/discover_overlay.py
@@ -38,7 +38,7 @@ except ModuleNotFoundError:
 
 log = logging.getLogger(__name__)
 t = gettext.translation(
-    'default', pkg_resources.resource_filename('discover_overlay', 'locales'))
+    'default', pkg_resources.resource_filename('discover_overlay', 'locales'), fallback=True)
 _ = t.gettext
 
 

--- a/discover_overlay/general_settings.py
+++ b/discover_overlay/general_settings.py
@@ -22,7 +22,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # nopep8
 
 t = gettext.translation(
-    'default', pkg_resources.resource_filename('discover_overlay', 'locales'))
+    'default', pkg_resources.resource_filename('discover_overlay', 'locales'), fallback=True)
 _ = t.gettext
 
 

--- a/discover_overlay/notification_settings.py
+++ b/discover_overlay/notification_settings.py
@@ -25,7 +25,7 @@ from gi.repository import Gtk, Gdk  # nopep8
 
 GUILD_DEFAULT_VALUE = "0"
 t = gettext.translation(
-    'default', pkg_resources.resource_filename('discover_overlay', 'locales'))
+    'default', pkg_resources.resource_filename('discover_overlay', 'locales'), fallback=True)
 _ = t.gettext
 
 

--- a/discover_overlay/settings.py
+++ b/discover_overlay/settings.py
@@ -33,7 +33,7 @@ except ModuleNotFoundError:
 
 log = logging.getLogger(__name__)
 t = gettext.translation(
-    'default', pkg_resources.resource_filename('discover_overlay', 'locales'))
+    'default', pkg_resources.resource_filename('discover_overlay', 'locales'), fallback=True)
 _ = t.gettext
 
 

--- a/discover_overlay/settings_window.py
+++ b/discover_overlay/settings_window.py
@@ -24,7 +24,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # nopep8
 
 t = gettext.translation(
-    'default', pkg_resources.resource_filename('discover_overlay', 'locales'))
+    'default', pkg_resources.resource_filename('discover_overlay', 'locales'), fallback=True)
 _ = t.gettext
 
 

--- a/discover_overlay/text_settings.py
+++ b/discover_overlay/text_settings.py
@@ -27,7 +27,7 @@ from gi.repository import Gtk, Gdk  # nopep8
 GUILD_DEFAULT_VALUE = "0"
 log = logging.getLogger(__name__)
 t = gettext.translation(
-    'default', pkg_resources.resource_filename('discover_overlay', 'locales'))
+    'default', pkg_resources.resource_filename('discover_overlay', 'locales'), fallback=True)
 _ = t.gettext
 
 

--- a/discover_overlay/voice_settings.py
+++ b/discover_overlay/voice_settings.py
@@ -22,7 +22,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk  # nopep8
 
 t = gettext.translation(
-    'default', pkg_resources.resource_filename('discover_overlay', 'locales'))
+    'default', pkg_resources.resource_filename('discover_overlay', 'locales'), fallback=True)
 _ = t.gettext
 
 


### PR DESCRIPTION
Without the fallback, the program will immediately crash at the start when it tries to load a translation that doesn't exist.

This PR should fix it. I just ran a find and replace, but I feel it could get hard to make more changes across all files in the future.