### PR TITLE
fixed offset when overlay anchored on the left

### DIFF
--- a/discover_overlay/voice_overlay.py
+++ b/discover_overlay/voice_overlay.py
@@ -546,7 +546,7 @@ class VoiceOverlayWindow(OverlayWindow):
                     if avatar_size < 8:
                         avatar_size = 8
 
-            current_x = 0
+            current_x = 0 + self.horz_edge_padding
             offset_x_mult = 1
             offset_x = avatar_size + self.horz_edge_padding
             if self.align_right:


### PR DESCRIPTION
when the overlay was anchored on the left, the horizontal offset wasn't working