### PR TITLE
Add discord-like sort option

### DIFF
--- a/discover_overlay/glade/settings.glade
+++ b/discover_overlay/glade/settings.glade
@@ -79,6 +79,9 @@
       <row>
         <col id="0" translatable="yes">Last Spoken</col>
       </row>
+      <row>
+        <col id="0" translatable="yes">Discord-like</col>
+      </row>
     </data>
   </object>
   <object class="GtkListStore" id="overflow_style_list">
@@ -1075,6 +1078,7 @@
                       <item translatable="yes">Alphabetically</item>
                       <item translatable="yes">ID</item>
                       <item translatable="yes">Last Spoken</item>
+                      <item translatable="yes">Discord-like</item>
                     </items>
                     <signal name="changed" handler="voice_order_avatars_by_changed" swapped="no"/>
                   </object>

--- a/discover_overlay/glade/settings.glade~
+++ b/discover_overlay/glade/settings.glade~
@@ -79,6 +79,9 @@
       <row>
         <col id="0" translatable="yes">Last Spoken</col>
       </row>
+      <row>
+        <col id="0" translatable="yes">Discord-like</col>
+      </row>
     </data>
   </object>
   <object class="GtkListStore" id="overflow_style_list">
@@ -1075,6 +1078,7 @@
                       <item translatable="yes">Alphabetically</item>
                       <item translatable="yes">ID</item>
                       <item translatable="yes">Last Spoken</item>
+                      <item translatable="yes">Discord-like</item>
                     </items>
                     <signal name="changed" handler="voice_order_avatars_by_changed" swapped="no"/>
                   </object>

--- a/discover_overlay/voice_overlay.py
+++ b/discover_overlay/voice_overlay.py
@@ -408,6 +408,8 @@ class VoiceOverlayWindow(OverlayWindow):
         elif self.order == 2:  # Spoken sort
             in_list.sort(key=lambda x: x["lastspoken"], reverse=True)
             in_list.sort(key=lambda x: x["speaking"], reverse=True)
+        elif self.order == 3:  # Discord-like
+            in_list.sort(key=lambda x: x["friendlyname"].lower())
         else:  # Name sort
             in_list.sort(key=lambda x: x["friendlyname"])
         return in_list


### PR DESCRIPTION
The fact that the order of the users in the overlay does not match the one inside Discord has bugged me for some time now.

Here is an example of what I mean.

Three users: alice#1111, Bob#3333 and charlie#2222
- Inside Discord the order is: alice, Bob, charlie
- Inside Discover the order can be:

    1. Alphabetical: Bob, alice, charlie
    2. ID: alice, charlie, Bob

My change (ignoring case) seems to be enough to replicate how Discord sorts the users.

Please note that I'm not at all familiar with glade, so I just changed the files that seemed to make sense. It works for me, but I suggest you check very carefully that everything is in order. I'm happy to make further edits if necessary.