### PR TITLE
Add optional grace period to "only_speaking"

### DIFF
--- a/discover_overlay/discover_overlay.py
+++ b/discover_overlay/discover_overlay.py
@@ -236,6 +236,8 @@ class Discover:
             "main", "square_avatar", fallback=True))
         self.voice_overlay.set_only_speaking(config.getboolean(
             "main", "only_speaking", fallback=False))
+        self.voice_overlay.set_only_speaking_grace_period(config.getint(
+            "main", "only_speaking_grace", fallback=0))
         self.voice_overlay.set_highlight_self(config.getboolean(
             "main", "highlight_self", fallback=False))
         self.voice_overlay.set_icon_only(config.getboolean(

--- a/discover_overlay/glade/settings.glade
+++ b/discover_overlay/glade/settings.glade
@@ -136,6 +136,13 @@
     <property name="step-increment">1</property>
     <property name="page-increment">8</property>
   </object>
+  <object class="GtkAdjustment" id="voice_display_speakers_grace_period_adj">
+    <property name="lower">0</property>
+    <property name="upper">360</property>
+    <property name="value">0</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="voice_nick_lenght_adj">
     <property name="lower">10</property>
     <property name="upper">32</property>
@@ -1300,6 +1307,32 @@
                 </child>
                 <child>
                   <object class="GtkLabel">
+                    <property name="name">voice_display_speakers_grace_period_label</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Speakers Grace Period</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">4</property>
+                    <property name="top-attach">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton">
+                    <property name="name">voice_display_speakers_grace_period</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="adjustment">voice_display_speakers_grace_period_adj</property>
+                    <signal name="value-changed" handler="voice_display_speakers_grace_period" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">5</property>
+                    <property name="top-attach">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
                     <property name="name">voice_nick_length_label</property>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -1308,7 +1341,7 @@
                   </object>
                   <packing>
                     <property name="left-attach">4</property>
-                    <property name="top-attach">6</property>
+                    <property name="top-attach">7</property>
                   </packing>
                 </child>
                 <child>
@@ -1321,7 +1354,7 @@
                   </object>
                   <packing>
                     <property name="left-attach">5</property>
-                    <property name="top-attach">6</property>
+                    <property name="top-attach">7</property>
                   </packing>
                 </child>
                 <child>

--- a/discover_overlay/settings_window.py
+++ b/discover_overlay/settings_window.py
@@ -310,6 +310,9 @@ class MainSettingsWindow():
         self.widget['voice_display_speakers_only'].set_active(
             config.getboolean("main", "only_speaking", fallback=False))
 
+        self.widget['voice_display_speakers_grace_period'].set_value(
+            config.getint("main", "only_speaking_grace", fallback=0))
+
         self.widget['voice_show_test_content'].set_active(
             config.getboolean("main", "show_dummy", fallback=False))
 
@@ -801,6 +804,9 @@ class MainSettingsWindow():
 
     def voice_display_speakers_only(self, button):
         self.config_set("main", "only_speaking", "%s" % (button.get_active()))
+
+    def voice_display_speakers_grace_period(self, button):
+        self.config_set("main", "only_speaking_grace", "%s" % (int(button.get_value())))
 
     def voice_toggle_test_content(self, button):
         self.config_set("main", "show_dummy", "%s" % (button.get_active()))


### PR DESCRIPTION
Add an optional grace period to "Display Speakers Only", so people who stop speaking aren't immediately hidden.

This works, but (sensibly) the "overlay_draw" function is only actually called when something changes. This means that if nobody speaks, which forces the overlay to redraw, then nobody will ever be hidden either.

To resolve this, I would have to force the overlay to re-render at least once per second. I have no idea how to do that, as I'm not familiar with GTK :smile:

What do you think, @trigg? Is it acceptable to force a minimum redraw interval of 1 second? It shouldn't actually make any difference to most people since the overlay already redraws multiple times per second in active voice channels.

If yes, how do I do that?

If no, do you have any alternative suggestions for how to implement this feature?