### PR TITLE
 Fix program crash when switching accounts due to empty unhandled WS message #1 

### DIFF
--- a/discover_overlay/discord_connector.py
+++ b/discover_overlay/discord_connector.py
@@ -760,6 +760,8 @@ class DiscordConnector:
             except websocket.WebSocketConnectionClosedException:
                 self.on_close()
                 return True
+            except json.decoder.JSONDecodeError:
+                return True
         return True
 
     def start_listening_text(self, channel):

--- a/discover_overlay/discord_connector.py
+++ b/discover_overlay/discord_connector.py
@@ -757,10 +757,8 @@ class DiscordConnector:
                     # Connection was closed in the meantime
                     return True
                 recv, _w, _e = select.select((self.websocket.sock,), (), (), 0)
-            except websocket.WebSocketConnectionClosedException:
+            except (websocket.WebSocketConnectionClosedException, json.decoder.JSONDecodeError):
                 self.on_close()
-                return True
-            except json.decoder.JSONDecodeError:
                 return True
         return True
 


### PR DESCRIPTION
Previously, the program would crash when attempting to switch accounts because an empty WS message was not being handled properly.

As long as it is handled, the previously implemented retry mechanism will handle account switching well
