### PR TITLE
Fall back to Xwayland if compositor has no layer shell protocol

### DIFF
--- a/discover_overlay/overlay.py
+++ b/discover_overlay/overlay.py
@@ -14,6 +14,7 @@
 Overlay parent class. Helpful if we need more overlay
 types without copy-and-pasting too much code
 """
+import sys
 import os
 import logging
 import gi
@@ -156,10 +157,9 @@ class OverlayWindow(Gtk.Window):
         """
         if self.is_wayland:
             if not GtkLayerShell.is_supported():
-                log.info(
-                    "GTK Layer Shell is not supported on this wayland compositor")
-                log.info("Currently not possible: Gnome, Weston")
-                self.discover.exit()
+                log.warn("GTK Layer Shell is not supported on this Wayland compositor.  Falling back to X11...")
+                os.environ["GDK_BACKEND"] = "x11"
+                os.execv(sys.argv[0], sys.argv)
             if not GtkLayerShell.is_layer_window(self):
                 GtkLayerShell.init_for_window(self)
             GtkLayerShell.set_layer(self, GtkLayerShell.Layer.OVERLAY)


### PR DESCRIPTION
Further to the discussion at https://github.com/trigg/Discover/issues/298#issuecomment-2036915484, here’s a patch to automatically set `GDK_BACKEND=x11` if an unsupported compositor is detected.

I’m marking this as draft because I rarely use Discord for voice these days, so don’t feel I’ve given this enough testing.  Perhaps someone else will want to do that testing, however, so here it is.