### PR TITLE
Use ink_rect's width and set alignment before getting dimensions

### DIFF
--- a/discover_overlay/voice_overlay.py
+++ b/discover_overlay/voice_overlay.py
@@ -862,6 +862,12 @@ class VoiceOverlayWindow(OverlayWindow):
         if font:
             font = Pango.FontDescription(font)
             layout.set_font_description(font)
+
+        if self.align_right:
+            layout.set_alignment(Pango.Alignment.RIGHT)
+        else:
+            layout.set_alignment(Pango.Alignment.LEFT)
+
         (ink_rect, logical_rect) = layout.get_pixel_extents()
         text_height = logical_rect.height
         text_width = logical_rect.width
@@ -883,10 +889,9 @@ class VoiceOverlayWindow(OverlayWindow):
 
             self.col(tx_col)
             context.move_to(
-                pos_x - text_width - self.text_pad - ink_rect.x,
+                (pos_x - self.text_pad) - (ink_rect.x + ink_rect.width),
                 pos_y + text_y_offset
             )
-            layout.set_alignment(Pango.Alignment.RIGHT)
             PangoCairo.show_layout(self.context, layout)
         else:
             context.move_to(0, 0)
@@ -901,10 +906,9 @@ class VoiceOverlayWindow(OverlayWindow):
 
             self.col(tx_col)
             context.move_to(
-                pos_x + self.text_pad + avatar_size- ink_rect.x,
+                (pos_x + self.text_pad + avatar_size) - ink_rect.x,
                 pos_y + text_y_offset
             )
-            layout.set_alignment(Pango.Alignment.LEFT)
             PangoCairo.show_layout(self.context, layout)
         context.restore()
         return text_width


### PR DESCRIPTION
1. Set the layout alignment before getting the box dimensions `(ink_rect, logical_rect) = layout.get_pixel_extents()`

	- This should fix #368 

2. use `ink_rect.width` instead of `logical_rect.width`
	- If you use the logical rect, for some special RTL cases, the text would be over the avatar or very close to it.
	- I noticed that the commit that made the #368 regression (https://github.com/trigg/Discover/commit/369ba964e2c43f802cedd526b0f3077d6b918869) was trying to solve some RTL issue, so I also tried to tackle this as well, there might be more RTL issues, but it should be better now.