### PR TITLE
improvements on current gtk-4 drastic branch

### DIFF
--- a/discover_overlay/discover_overlay.py
+++ b/discover_overlay/discover_overlay.py
@@ -22,12 +22,12 @@ import signal
 import importlib_resources
 from configparser import ConfigParser
 from ctypes import CDLL
-from ._version import __version__
 
 CDLL("libgtk4-layer-shell.so")
 
 import gi
 
+from ._version import __version__
 from .overlay import OverlayWindow
 from .settings_window import Settings
 from .voice_overlay import VoiceOverlayWindow

--- a/discover_overlay/glade/settings.xml
+++ b/discover_overlay/glade/settings.xml
@@ -705,7 +705,7 @@
                     <signal name="changed" handler="voice_text_side_changed" swapped="no" />
                     <layout>
                       <property name="column">5</property>
-                      <property name="row">11</property>
+                      <property name="row">12</property>
                     </layout>
                   </object>
                 </child>
@@ -716,7 +716,7 @@
                     <property name="xalign">0</property>
                     <layout>
                       <property name="column">4</property>
-                      <property name="row">11</property>
+                      <property name="row">12</property>
                     </layout>
                   </object>
                 </child>
@@ -1199,12 +1199,34 @@
                 </child>
                 <child>
                   <object class="GtkLabel">
+                    <property name="name">voice_text_border_label</property>
+                    <property name="label" translatable="1">Border around text</property>
+                    <property name="xalign">0</property>
+                    <layout>
+                      <property name="column">4</property>
+                      <property name="row">5</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton">
+                    <property name="name">voice_text_border</property>
+                    <property name="focusable">1</property>
+                    <signal name="toggled" handler="voice_text_border_changed" swapped="no" />
+                    <layout>
+                      <property name="column">5</property>
+                      <property name="row">5</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
                     <property name="name">voice_border_width_label</property>
                     <property name="label" translatable="1">Border width</property>
                     <property name="xalign">0</property>
                     <layout>
                       <property name="column">4</property>
-                      <property name="row">5</property>
+                      <property name="row">6</property>
                     </layout>
                   </object>
                 </child>
@@ -1218,7 +1240,7 @@
                     <signal name="value-changed" handler="voice_border_width_changed" swapped="no" />
                     <layout>
                       <property name="column">5</property>
-                      <property name="row">5</property>
+                      <property name="row">6</property>
                     </layout>
                   </object>
                 </child>
@@ -1229,7 +1251,7 @@
                     <property name="xalign">0</property>
                     <layout>
                       <property name="column">4</property>
-                      <property name="row">6</property>
+                      <property name="row">7</property>
                     </layout>
                   </object>
                 </child>
@@ -1242,7 +1264,7 @@
                     <signal name="value-changed" handler="voice_icon_spacing_changed" swapped="no" />
                     <layout>
                       <property name="column">5</property>
-                      <property name="row">6</property>
+                      <property name="row">7</property>
                     </layout>
                   </object>
                 </child>
@@ -1255,7 +1277,7 @@
                     <signal name="clicked" handler="voice_reset_all" swapped="no" />
                     <layout>
                       <property name="column">5</property>
-                      <property name="row">12</property>
+                      <property name="row">14</property>
                     </layout>
                   </object>
                 </child>
@@ -1266,7 +1288,7 @@
                     <property name="xalign">0</property>
                     <layout>
                       <property name="column">4</property>
-                      <property name="row">7</property>
+                      <property name="row">8</property>
                     </layout>
                   </object>
                 </child>
@@ -1277,7 +1299,7 @@
                     <property name="xalign">0</property>
                     <layout>
                       <property name="column">4</property>
-                      <property name="row">8</property>
+                      <property name="row">9</property>
                     </layout>
                   </object>
                 </child>
@@ -1288,7 +1310,7 @@
                     <property name="xalign">0</property>
                     <layout>
                       <property name="column">4</property>
-                      <property name="row">9</property>
+                      <property name="row">10</property>
                     </layout>
                   </object>
                 </child>
@@ -1299,7 +1321,7 @@
                     <property name="xalign">0</property>
                     <layout>
                       <property name="column">4</property>
-                      <property name="row">10</property>
+                      <property name="row">11</property>
                     </layout>
                   </object>
                 </child>
@@ -1310,7 +1332,7 @@
                     <signal name="toggled" handler="inactive_fade_changed" swapped="no" />
                     <layout>
                       <property name="column">5</property>
-                      <property name="row">7</property>
+                      <property name="row">8</property>
                     </layout>
                   </object>
                 </child>
@@ -1325,7 +1347,7 @@
                       swapped="no" />
                     <layout>
                       <property name="column">5</property>
-                      <property name="row">8</property>
+                      <property name="row">9</property>
                     </layout>
                   </object>
                 </child>
@@ -1338,7 +1360,7 @@
                     <signal name="value-changed" handler="inactive_time_changed" swapped="no" />
                     <layout>
                       <property name="column">5</property>
-                      <property name="row">9</property>
+                      <property name="row">10</property>
                     </layout>
                   </object>
                 </child>
@@ -1351,7 +1373,7 @@
                     <signal name="value-changed" handler="inactive_fade_time_changed" swapped="no" />
                     <layout>
                       <property name="column">5</property>
-                      <property name="row">10</property>
+                      <property name="row">11</property>
                     </layout>
                   </object>
                 </child>

--- a/discover_overlay/glade/settings.xml
+++ b/discover_overlay/glade/settings.xml
@@ -400,11 +400,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">voice_talking_foreground</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="voice_talking_foreground_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="voice_talking_foreground_changed" swapped="no" />
                     <layout>
                       <property name="column">3</property>
                       <property name="row">1</property>
@@ -412,11 +419,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">voice_talking_background</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="voice_talking_background_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="voice_talking_background_changed" swapped="no" />
                     <layout>
                       <property name="column">4</property>
                       <property name="row">1</property>
@@ -424,11 +438,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">voice_talking_border</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="voice_talking_border_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="voice_talking_border_changed" swapped="no" />
                     <layout>
                       <property name="column">5</property>
                       <property name="row">1</property>
@@ -436,11 +457,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">voice_idle_foreground</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="voice_idle_foreground_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="voice_idle_foreground_changed" swapped="no" />
                     <layout>
                       <property name="column">3</property>
                       <property name="row">2</property>
@@ -448,11 +476,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">voice_idle_background</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="voice_idle_background_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="voice_idle_background_changed" swapped="no" />
                     <layout>
                       <property name="column">4</property>
                       <property name="row">2</property>
@@ -460,11 +495,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">voice_idle_border</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="voice_idle_border_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="voice_idle_border_changed" swapped="no" />
                     <layout>
                       <property name="column">5</property>
                       <property name="row">2</property>
@@ -472,11 +514,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">voice_mute_foreground</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="voice_mute_foreground_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="voice_mute_foreground_changed" swapped="no" />
                     <layout>
                       <property name="column">3</property>
                       <property name="row">3</property>
@@ -484,11 +533,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">voice_mute_background</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="voice_mute_background_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="voice_mute_background_changed" swapped="no" />
                     <layout>
                       <property name="column">4</property>
                       <property name="row">3</property>
@@ -496,11 +552,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">voice_avatar_background</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="voice_avatar_background_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="voice_avatar_background_changed" swapped="no" />
                     <layout>
                       <property name="column">4</property>
                       <property name="row">4</property>
@@ -1429,11 +1492,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">text_background_colour</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="text_background_colour_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="text_background_colour_changed" swapped="no" />
                     <layout>
                       <property name="column">1</property>
                       <property name="row">8</property>
@@ -1452,11 +1522,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">text_colour</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="text_colour_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="text_colour_changed" swapped="no" />
                     <layout>
                       <property name="column">1</property>
                       <property name="row">7</property>
@@ -1858,11 +1935,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">notification_text_colour</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="notification_text_colour_changed" swapped="no" />
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="notification_text_colour_changed" swapped="no" />
                     <layout>
                       <property name="column">1</property>
                       <property name="row">5</property>
@@ -1870,11 +1954,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkColorButton">
+                  <object class="GtkColorDialogButton">
                     <property name="name">notification_background_colour</property>
                     <property name="focusable">1</property>
                     <property name="receives-default">1</property>
-                    <signal name="color-set" handler="notification_background_colour_changed"
+                    <property name="dialog">
+                      <object class="GtkColorDialog">
+                        <property name="title">Select Color</property>
+                        <property name="modal">1</property>
+                        <property name="with-alpha">1</property>
+                      </object>
+                    </property>
+                    <signal name="notify::rgba" handler="notification_background_colour_changed"
                       swapped="no" />
                     <layout>
                       <property name="column">1</property>

--- a/discover_overlay/layout.py
+++ b/discover_overlay/layout.py
@@ -11,6 +11,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Collection of LayoutManagers used throughout"""
+
 import logging
 from enum import Enum
 import gi
@@ -288,7 +289,7 @@ class UserBoxLayout(Gtk.LayoutManager):
         else:
             widget.label.set_valign(Gtk.Align.END)
 
-        widget.image.size_allocate(img_alloc, -1)
+        widget.image_wrapper.size_allocate(img_alloc, -1)
         widget.label.size_allocate(lbl_alloc, -1)
         widget.mute.size_allocate(img_alloc, -1)
         widget.deaf.size_allocate(img_alloc, -1)

--- a/discover_overlay/layout.py
+++ b/discover_overlay/layout.py
@@ -274,13 +274,23 @@ class UserBoxLayout(Gtk.LayoutManager):
             lbl_alloc.x = lbl_alloc.y = 0
             lbl_alloc.width = width
 
-        tx = widget.overlay.text_x_align
-        if tx == "left":
+        # i hope this isn't needed anymore
+        # tx = widget.overlay.text_x_align
+        # if tx == "left":
+        #     widget.label.set_halign(Gtk.Align.START)
+        # elif tx == "middle":
+        #     widget.label.set_halign(Gtk.Align.CENTER)
+        # else:
+        #     widget.label.set_halign(Gtk.Align.END)
+        if direction == Direction.LTR:
             widget.label.set_halign(Gtk.Align.START)
-        elif tx == "middle":
+        elif direction == Direction.TTB:
+            widget.label.set_halign(Gtk.Align.CENTER)
+        elif direction == Direction.BTT:
             widget.label.set_halign(Gtk.Align.CENTER)
         else:
             widget.label.set_halign(Gtk.Align.END)
+
         ty = widget.overlay.text_y_align
         if ty == "top":
             widget.label.set_valign(Gtk.Align.START)

--- a/discover_overlay/notification_overlay.py
+++ b/discover_overlay/notification_overlay.py
@@ -11,6 +11,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Notification window for text"""
+
 import logging
 import json
 import cairo
@@ -92,10 +93,17 @@ class NotificationOverlayWindow(Gtk.Box):
         self.text_align = "left"
         self.align_x = HorzAlign.RIGHT
         self.align_y = VertAlign.TOP
+        self.enabled = False
         self.show()
+
+    def set_enabled(self, enabled):
+        """Set if notifications should be enabled"""
+        self.enabled = enabled
 
     def add_notification_message(self, data):
         """Add new message to dataset"""
+        if not self.enabled:
+            return
         if "data" in data:
             data = data["data"]
         if "body" in data or "title" in data:
@@ -201,6 +209,7 @@ class NotificationOverlayWindow(Gtk.Box):
 
     def set_config(self, config):
         """Read in config section and set self and children accordingly"""
+        self.set_enabled(config.getboolean("enabled", fallback=False))
         font = config.get("font", fallback=None)
         self.align_x = get_h_align(config.get("align_x", "right"))
         self.align_y = get_v_align(config.get("align_y", "top"))

--- a/discover_overlay/settings_window.py
+++ b/discover_overlay/settings_window.py
@@ -886,47 +886,47 @@ class Settings(Gtk.Application):
     def voice_toggle_test_content(self, button):
         self.config_set("main", "show_dummy", f"{button.get_active()}")
 
-    def voice_talking_foreground_changed(self, button):
+    def voice_talking_foreground_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("main", "fg_hi_col", json.dumps(colour))
 
-    def voice_talking_background_changed(self, button):
+    def voice_talking_background_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("main", "hi_col", json.dumps(colour))
 
-    def voice_talking_border_changed(self, button):
+    def voice_talking_border_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("main", "tk_col", json.dumps(colour))
 
-    def voice_idle_foreground_changed(self, button):
+    def voice_idle_foreground_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("main", "fg_col", json.dumps(colour))
 
-    def voice_idle_background_changed(self, button):
+    def voice_idle_background_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("main", "bg_col", json.dumps(colour))
 
-    def voice_idle_border_changed(self, button):
+    def voice_idle_border_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("main", "bo_col", json.dumps(colour))
 
-    def voice_mute_foreground_changed(self, button):
+    def voice_mute_foreground_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("main", "mt_col", json.dumps(colour))
 
-    def voice_mute_background_changed(self, button):
+    def voice_mute_background_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("main", "mt_bg_col", json.dumps(colour))
 
-    def voice_avatar_background_changed(self, button):
+    def voice_avatar_background_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("main", "avatar_bg_col", json.dumps(colour))
@@ -1028,12 +1028,12 @@ class Settings(Gtk.Application):
     def text_font_changed(self, button):
         self.config_set("text", "font", button.get_font())
 
-    def text_colour_changed(self, button):
+    def text_colour_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("text", "fg_col", json.dumps(colour))
 
-    def text_background_colour_changed(self, button):
+    def text_background_colour_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("text", "bg_col", json.dumps(colour))
@@ -1083,12 +1083,12 @@ class Settings(Gtk.Application):
     def notification_font_changed(self, button):
         self.config_set("notification", "font", button.get_font())
 
-    def notification_text_colour_changed(self, button):
+    def notification_text_colour_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("notification", "fg_col", json.dumps(colour))
 
-    def notification_background_colour_changed(self, button):
+    def notification_background_colour_changed(self, button, _param=None):
         colour = button.get_rgba()
         colour = [colour.red, colour.green, colour.blue, colour.alpha]
         self.config_set("notification", "bg_col", json.dumps(colour))

--- a/discover_overlay/settings_window.py
+++ b/discover_overlay/settings_window.py
@@ -737,7 +737,12 @@ class Settings(Gtk.Application):
     def make_colour(self, col):
         """Create a Gdk Color from a col tuple"""
         col = json.loads(col)
-        return Gdk.RGBA(col[0], col[1], col[2], col[3])
+        rgba = Gdk.RGBA()
+        rgba.red = col[0]
+        rgba.green = col[1]
+        rgba.blue = col[2]
+        rgba.alpha = col[3]
+        return rgba
 
     def parse_guild_ids(self, guild_ids_str):
         """Parse the guild_ids from a str and return them in a list"""
@@ -954,7 +959,7 @@ class Settings(Gtk.Application):
         self.config_set("main", "border_width", f"{int(button.get_value())}")
 
     def voice_avatar_circle_changed(self, button):
-        self.config_set("main", "square_avatar", f"{ not button.get_active()}")
+        self.config_set("main", "square_avatar", f"{not button.get_active()}")
 
     def voice_show_title_changed(self, button):
         self.config_set("main", "show_title", f"{button.get_active()}")

--- a/discover_overlay/settings_window.py
+++ b/discover_overlay/settings_window.py
@@ -533,6 +533,10 @@ class Settings(Gtk.Application):
             config.getint("main", "order", fallback=0)
         )
 
+        self.widget["voice_text_border"].set_active(
+            config.getboolean("main", "text_border", fallback=True)
+        )
+
         self.widget["voice_border_width"].set_value(
             config.getint("main", "border_width", fallback=2)
         )
@@ -954,6 +958,9 @@ class Settings(Gtk.Application):
 
     def voice_order_avatars_by_changed(self, button):
         self.config_set("main", "order", f"{button.get_active()}")
+
+    def voice_text_border_changed(self, button):
+        self.config_set("main", "text_border", f"{button.get_active()}")
 
     def voice_border_width_changed(self, button):
         self.config_set("main", "border_width", f"{int(button.get_value())}")

--- a/discover_overlay/text_overlay.py
+++ b/discover_overlay/text_overlay.py
@@ -11,6 +11,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Overlay window for text"""
+
 import logging
 import gi
 import cairo
@@ -45,7 +46,12 @@ class TextOverlayWindow(Gtk.Box):
         self.height_limit = 300
         self.align_x = HorzAlign.RIGHT
         self.align_y = VertAlign.BOTTOM
+        self.enabled = False
         self.show()
+
+    def set_enabled(self, enabled):
+        """Set if text overlay should be enabled"""
+        self.enabled = enabled
 
     def set_blank(self):
         """Set contents blank and redraw"""
@@ -58,6 +64,8 @@ class TextOverlayWindow(Gtk.Box):
 
     def new_line(self, message):
         """Add a new message to text overlay. Does not sanity check the data"""
+        if not self.enabled:
+            return
         message = Message(self, message)
         if not message.skip:
             self.append(message)
@@ -104,6 +112,7 @@ class TextOverlayWindow(Gtk.Box):
 
     def set_config(self, config):
         """Set self and children from config"""
+        self.set_enabled(config.getboolean("enabled", fallback=False))
         channel = config.get("channel", fallback="0")
         guild = config.get("guild", fallback="0")
         self.discover.connection.set_text_channel(channel, guild)

--- a/discover_overlay/userbox.py
+++ b/discover_overlay/userbox.py
@@ -11,6 +11,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """A Gtk Box with direction"""
+
 import gettext
 import logging
 import gi
@@ -55,9 +56,14 @@ class UserBox(Gtk.Box):
         self.deaf = Gtk.Image()
 
         self.image.set_overflow(Gtk.Overflow.HIDDEN)
+        self.image.add_css_class("usericon-image")
 
-        self.image.add_css_class("usericon")
+        self.image_wrapper = Gtk.Box()
+        self.image_wrapper.add_css_class("usericon")
+        self.image_wrapper.append(self.image)
+
         self.label.add_css_class("userlabel")
+
         self.mute.add_css_class("usermute")
         self.deaf.add_css_class("userdeaf")
 
@@ -69,7 +75,7 @@ class UserBox(Gtk.Box):
         self.deaf.set_valign(Gtk.Align.CENTER)
 
         self.append(self.label)
-        self.append(self.image)
+        self.append(self.image_wrapper)
         self.append(self.mute)
         self.append(self.deaf)
 

--- a/discover_overlay/voice_overlay.py
+++ b/discover_overlay/voice_overlay.py
@@ -594,6 +594,10 @@ class VoiceOverlayWindow(Gtk.Box):
 
         self.update_all()
 
+        for child in self:
+            if isinstance(child, UserBox):
+                child.queue_resize()
+
     def set_css(self, css_id, rule):
         """Add or replace CSS Rule"""
         self.get_root().set_css(css_id, rule)

--- a/discover_overlay/voice_overlay.py
+++ b/discover_overlay/voice_overlay.py
@@ -62,6 +62,7 @@ class VoiceOverlayWindow(Gtk.Box):
         self.use_dummy = False
         self.dummy_count = 10
         self.border_width = 2
+        self.text_border = True
         self.only_speaking_grace_period = 0
         self.text_side = 3
         self.rounded_avatar = True
@@ -360,6 +361,18 @@ class VoiceOverlayWindow(Gtk.Box):
         col = col_to_css(self.border_col)
         talk_col = col_to_css(self.talk_col)
         rounded = "border-radius: 50%;" if self.rounded_avatar else ""
+        text_border = ""
+        if self.text_border:
+            text_border = f"""
+            .userlabel
+            {{
+              outline: {width}px solid {col};
+            }}
+            .talking .userlabel
+            {{
+              outline: {width}px solid {talk_col};
+            }}
+            """
         self.set_css(
             "talking-border",
             f"""
@@ -380,6 +393,7 @@ class VoiceOverlayWindow(Gtk.Box):
               {rounded}
             }}
             .container {{ padding: {width}px; }}
+            {text_border}
             """,
         )
 
@@ -557,6 +571,7 @@ class VoiceOverlayWindow(Gtk.Box):
             config.getboolean("show_disconnected", fallback=True)
         )
         self.border_width = config.getint("border_width", fallback=2)
+        self.text_border = config.getboolean("text_border", fallback=True)
 
         self.show_avatar = config.getboolean("show_avatar", fallback=True)
 

--- a/discover_overlay/voice_overlay.py
+++ b/discover_overlay/voice_overlay.py
@@ -356,33 +356,30 @@ class VoiceOverlayWindow(Gtk.Box):
     def set_borders(self):
         """Update all border CSS rules based on config"""
         width = self.border_width
+        half = width / 2
         col = col_to_css(self.border_col)
         talk_col = col_to_css(self.talk_col)
         rounded = "border-radius: 50%;" if self.rounded_avatar else ""
-
-        drop_shadow_normal = ""
-        drop_shadow_talking = ""
-        for j in range(0, width+1):
-            drop_shadow_talking += f" drop-shadow(0px 0px {width}px {talk_col})"
-            drop_shadow_normal += f" drop-shadow(0px 0px {width}px {col})"
-            # Pile up extra filters to darken the effect... This is such a stupid idea
-
         self.set_css(
             "talking-border",
             f"""
-            .talking.user
+            .talking .usericon
             {{
-              filter: {drop_shadow_talking};
+              outline: {width}px solid {talk_col};
+              outline-offset: -{half}px;
+              {rounded}
             }}
-            .user
+            .usericon
             {{
-              filter: {drop_shadow_normal};
+              outline: {width}px solid {col};
+              outline-offset: -{half}px;
+              {rounded}
             }}
             .usericon, .usermute, .userdeaf
             {{
                 {rounded}
             }}
-            .container {{ padding: {width*2}px; }}
+            .container {{ padding: {width}px; }}
             """,
         )
 

--- a/discover_overlay/voice_overlay.py
+++ b/discover_overlay/voice_overlay.py
@@ -11,6 +11,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Overlay window for voice"""
+
 import random
 import gettext
 import logging
@@ -298,7 +299,6 @@ class VoiceOverlayWindow(Gtk.Box):
         now = perf_counter()
         time_percent = (now - self.fade_start) / self.inactive_fade_time
         if time_percent >= 1.0:
-
             fade_opacity = self.fade_out_limit
             self.fadeout_timeout = None
             self.set_css("fade-out", ".container { opacity: %2.2f;}" % (fade_opacity))
@@ -375,9 +375,9 @@ class VoiceOverlayWindow(Gtk.Box):
               outline-offset: -{half}px;
               {rounded}
             }}
-            .usericon, .usermute, .userdeaf
+            .usericon-image, .usermute, .userdeaf
             {{
-                {rounded}
+              {rounded}
             }}
             .container {{ padding: {width}px; }}
             """,
@@ -562,7 +562,7 @@ class VoiceOverlayWindow(Gtk.Box):
 
         self.set_css(
             "icon_transparency",
-            ".usericon { opacity: %2.2f; }"
+            ".usericon-image { opacity: %2.2f; }"
             % (config.getfloat("icon_transparency", fallback=1.0)),
         )
 


### PR DESCRIPTION
few main improvements involves:
- changing the text side wouldn't update the ui right away
- opacity selector in color picker
- show borders like outline (like how its shown in discord)
- have the ability to turn off border around the username in settings(it might need restarting overlay to show change)

known caveats that still exist:
- changing some of the setting of option doesn't reflect the overlay right away, might have to restart the overlay to see affect
- alignment sometimes leaves some padding even though padding is set to 0 by default, mostly happens when overlay first appears, changing the x or y align snaps it to side.