### PR TITLE
Re-apply input shape when the overlay window is recreated

### DIFF
--- a/discover_overlay/overlay.py
+++ b/discover_overlay/overlay.py
@@ -117,6 +117,12 @@ class OverlayWindow(Gtk.Window):
                                          | Gdk.EventMask.ENTER_NOTIFY_MASK)
         self.connect("enter-notify-event", self.mouseover)
         self.connect("leave-notify-event", self.mouseout)
+        # The input shape lives on the GdkWindow, so it is discarded whenever
+        # that window is recreated (outputs removed and re-added, layer surface
+        # rebuilt). Re-apply it on realize/map rather than relying on any one
+        # event, so the overlay can never come back input-opaque.
+        self.connect("realize", self.shape_on_realize)
+        self.connect("map-event", self.shape_on_map)
         self.mouse_over_timer = None
 
         # It shouldn't be possible, but let's not leave
@@ -253,6 +259,46 @@ class OverlayWindow(Gtk.Window):
         surface_ctx.paint()
         reg = Gdk.cairo_region_create_from_surface(surface)
         self.input_shape_combine_region(reg)
+
+    def reapply_input_shape(self):
+        """
+        Re-apply the input region.
+
+        The input shape is a property of the underlying GdkWindow. When outputs
+        are removed and re-added (screen power-off, monitor hotplug) the layer
+        surface and its GdkWindow are destroyed and recreated, and the shape is
+        lost. A window with no input shape captures *all* pointer input, so an
+        overlay-layer window spanning the desktop then swallows every click
+        while keyboard input still works.
+
+        Default to fully click-through, which is always safe; when hiding on
+        mouseover the next draw restores the content-shaped region.
+        """
+        if not self.get_window():
+            return
+        self.set_untouchable()
+        if self.hide_on_mouseover:
+            self.set_needs_redraw()
+
+    def shape_on_realize(self, _w=None):
+        """Restore the input shape when a new GdkWindow is created."""
+        GLib.idle_add(self.reapply_input_shape_deferred)
+
+    def shape_on_map(self, _w=None, _e=None):
+        """Restore the input shape when the window is (re)mapped."""
+        GLib.idle_add(self.reapply_input_shape_deferred)
+        return False
+
+    def reapply_input_shape_deferred(self):
+        """
+        Re-apply the input shape once GTK has settled.
+
+        Surface recreation after an output change is asynchronous, so a shape
+        applied immediately can be set on a window that is then replaced. Run
+        again on idle to cover that case.
+        """
+        self.reapply_input_shape()
+        return False
 
     def set_hide_on_mouseover(self, hide):
         """Set if the overlay should hide when mouse moves over it"""
@@ -472,8 +518,16 @@ class OverlayWindow(Gtk.Window):
         self.redraw()
 
     def screen_changed(self, _screen=None):
-        """Callback to set monitor to display on"""
+        """
+        Callback for monitors-changed / size-changed.
+
+        Force the update: this always passes the current plug name, so an
+        unforced set_monitor() would compare it against itself, take the
+        unchanged path and do nothing at all.
+        """
         self.set_monitor(self.monitor)
+        self.reapply_input_shape()
+        GLib.idle_add(self.reapply_input_shape_deferred)
 
     def mouseover(self, _a=None, _b=None):
         """Callback when mouseover occurs, hides overlay"""


### PR DESCRIPTION
Fixes #383.

## Symptom

After an output change — screen power-off following an auto-lock, or a monitor hotplug — the overlay silently swallows every mouse click on the desktop. Keyboard input keeps working. Killing discover-overlay restores clicking immediately.

[KDE bug 518349](https://bugs.kde.org/show_bug.cgi?id=518349) was eventually traced to the same thing and is marked RESOLVED UPSTREAM against Discover rather than KWin.

## Root cause

The overlay is a layer-shell window at the OVERLAY layer spanning the whole desktop. `set_untouchable()` makes it click-through by installing an empty input region (`wl_surface.set_input_region` with an empty `wl_region`).

That region belongs to the GdkWindow. Removing and re-adding an output destroys and recreates the layer surface, and nothing re-applies the region afterwards. A Wayland surface with **no** input region accepts *all* pointer input — so a full-desktop OVERLAY-layer surface then eats every click.

`screen_changed()` looks like it should cover this, but it is a no-op:

```python
def screen_changed(self, _screen=None):
    self.set_monitor(self.monitor)      # passes self.monitor ...

def set_monitor(self, idx=None):
    plug_name = f"{idx}"
    if self.monitor != plug_name:       # ... and compares it against itself
        ...
        self.set_untouchable()          # never reached
```

`plug_name` is that same value stringified, so the guard is always false and the body — including `set_untouchable()` — never runs.

## Fix

Re-apply the input shape on `realize` and `map-event`. Hooking window creation rather than any single event means the overlay cannot come back input-opaque regardless of what triggered the rebuild. It defaults to fully click-through, which is always safe; when hiding on mouseover the next draw restores the content-shaped region.

I deliberately did **not** "fix" `screen_changed`. Making it fire does resolve the symptom, but it then takes the `hide()` / `set_wayland_state()` / `show()` path on every output change, which rebuilt the surface 16 times for a single hotplug. The realize/map hooks get the same result with 2.

## How to reproduce and verify

Tested on KWin 6.6.6 / Plasma 6.6.6, Wayland. Any compositor with `zwlr_layer_shell_v1` and a hotpluggable output works; a real second monitor being plugged/unplugged reproduces it identically.

**1. Get a hotpluggable output** (skip if using a real second monitor):

```sh
sudo modprobe vkms          # adds a virtual output, e.g. Virtual-1
kscreen-doctor -o           # confirm it appears
```

**2. Run the overlay with protocol tracing:**

```sh
WAYLAND_DEBUG=1 discover-overlay > /tmp/do.log 2>&1 &
sleep 8
```

**3. Remove and re-add the output** (or physically unplug/replug a monitor):

```sh
kscreen-doctor output.Virtual-1.disable ; sleep 4
kscreen-doctor output.Virtual-1.enable  ; sleep 5
```

**4. Check every surviving layer surface for an input region:**

```sh
python3 - /tmp/do.log <<'EOF'
import re, sys, io
log = io.open(sys.argv[1], encoding="utf-8", errors="replace").read().splitlines()
created, destroyed, region, layer = [], set(), {}, set()
for i, l in enumerate(log):
    m = re.search(r'create_surface\(new id wl_surface#(\d+)\)', l)
    if m: created.append((int(m.group(1)), i))
    m = re.search(r'wl_surface#(\d+)\.destroy\(\)', l)
    if m: destroyed.add((int(m.group(1)), i))
    m = re.search(r'wl_surface#(\d+)\.set_input_region', l)
    if m: region.setdefault(int(m.group(1)), []).append(i)
    m = re.search(r'get_layer_surface\(new id zwlr_layer_surface_v1#\d+, wl_surface#(\d+),', l)
    if m: layer.add(int(m.group(1)))
alive = [(s, c) for s, c in created if not any(d == s and di > c for d, di in destroyed)]
bad = 0
for sid, ci in alive:
    if sid not in layer:
        continue          # GTK-internal surface, never on screen
    ok = any(i > ci for i in region.get(sid, []))
    print(f"layer wl_surface#{sid}: input region {'YES' if ok else 'NO  <-- captures all input'}")
    if not ok:
        bad += 1
print("RESULT:", "PASS" if bad == 0 else f"FAIL ({bad} surface(s) capture all input)")
EOF
```

**5. Confirm by hand:** try clicking any window.

### Results

Before this patch:

```
layer wl_surface#39: input region NO  <-- captures all input
RESULT: FAIL (1 surface(s) capture all input)
```

The relevant trace, showing the surface being recreated with no region re-applied:

```
wl_registry.global_remove(81)              <- output removed
wl_surface#43.destroy()
create_surface(new id wl_surface#45)
wl_surface#45.set_input_region(wl_region#44)
wl_surface#45.destroy()
create_surface(new id wl_surface#39)
get_layer_surface(..., wl_surface#39, ...)
                                           <- no set_input_region
```

Step 5 at this point: **clicks are dead** — no window responds, keyboard still works.

After this patch:

```
layer wl_surface#42: input region YES
RESULT: PASS
```

Step 5 at this point: **clicks work normally.** Stable across repeated hotplug cycles, and 2 surface recreations per hotplug rather than 16.

## Full disclosure

This patch was developed with AI assistance (Claude Code, Anthropic). The investigation, the code change, and the `WAYLAND_DEBUG` verification tooling above were produced by the model; I directed the work, ran the privileged and manual steps (`modprobe vkms`, the by-hand click tests at both ends), reviewed the result, and signed the commit.
